### PR TITLE
Dogyear/bubble fix

### DIFF
--- a/src/components/Charts.js
+++ b/src/components/Charts.js
@@ -216,10 +216,10 @@ export default class Charts extends Component {
                             xAxes: [{
                                 ticks: {
                                     min: 0,
-                                    max: 1,
+                                    max: companyNames.length,
                                     stepSize: 1,
-                                    maxRotation: 65,
-                                    minRotation: 65,
+                                    maxRotation: 80,
+                                    minRotation: 80,
                                     callback: function(value, index, values) {
                                         return companyNames[index];
                                     }

--- a/src/components/Charts.js
+++ b/src/components/Charts.js
@@ -215,13 +215,17 @@ export default class Charts extends Component {
                         scales: {
                             xAxes: [{
                                 ticks: {
-                                    min: 0,
+                                    min: -1,
                                     max: companyNames.length,
+                                    beginAtZero: true,
                                     stepSize: 1,
                                     maxRotation: 80,
                                     minRotation: 80,
                                     callback: function(value, index, values) {
-                                        return companyNames[index];
+                                        if (index === 0) {
+                                            return ""
+                                        }
+                                        return companyNames[index - 1];
                                     }
                                 }
                             }],


### PR DESCRIPTION
* shifted the bubble chart to the middle of the x-axis
* fixed: when "all" is selected, show all the companies rather than only 2 (Airbnb, Google)

* did not handle: when all is selected, bubble chart shows all the data, and skips some company names to make itself fit in the card.